### PR TITLE
Update for Visual Studio 2022

### DIFF
--- a/run-tcp-server-vs2022.bat
+++ b/run-tcp-server-vs2022.bat
@@ -7,24 +7,44 @@ echo.
 cd /d "%~dp0"
 
 REM Set MSBuild path to VS2022 (adjust path as needed)
-set "MSBUILD_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
-if not exist "%MSBUILD_PATH%" (
-    set "MSBUILD_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
-)
-if not exist "%MSBUILD_PATH%" (
-    set "MSBUILD_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
-)
-if not exist "%MSBUILD_PATH%" (
-    set "MSBUILD_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
+setlocal EnableDelayedExpansion
+
+set "paths[0]=C:\Program Files (x86)\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
+set "paths[1]=C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
+set "paths[2]=C:\Program Files (x86)\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+set "paths[3]=C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
+set "paths[4]=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
+set "paths[5]=C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin"
+set "paths[6]=C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin"
+set "paths[7]=C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin"
+set "paths[8]=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin"
+set "paths[9]=C:\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
+
+set "MSBUILD_PATH="
+for /L %%i in (0,1,9) do (
+    call set "currentPath=%%paths[%%i]%%"
+    if exist "!currentPath!" (
+        set "MSBUILD_PATH=!currentPath!"
+        goto :found
+    )
 )
 
-echo Using MSBuild from: %MSBUILD_PATH%
+:found
+if defined MSBUILD_PATH (
+    echo Using MSBuild from: %MSBUILD_PATH%
+) else (
+    echo Error: MSBuild path not found.
+    pause
+)
 
+echo.
+
+REM Run DotNetFramework MCP Server
 if exist "publish\DotNetFrameworkMCP.Server.exe" (
     echo Using compiled executable...
-    publish\DotNetFrameworkMCP.Server.exe --port 3001
+    "publish\DotNetFrameworkMCP.Server.exe" --port 3001
 ) else (
-    echo Using dotnet run (building if needed)...
+    echo Using dotnet run, building if needed...
     dotnet run --project "src\DotNetFrameworkMCP.Server" -- --port 3001
 )
 

--- a/src/DotNetFrameworkMCP.Server/Executors/MSBuildExecutor.cs
+++ b/src/DotNetFrameworkMCP.Server/Executors/MSBuildExecutor.cs
@@ -119,10 +119,12 @@ public class MSBuildExecutor : IBuildExecutor
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"),
+                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"),
+                Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe")
             });
         }
@@ -147,10 +149,12 @@ public class MSBuildExecutor : IBuildExecutor
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"),
+                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"),
+                Path.Combine(programFiles, @"Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFiles, @"Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe"),
                 Path.Combine(programFilesX86, @"Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"),


### PR DESCRIPTION
1. Update run-tcp-server-vs2022.bat
- Remove invalid parentheses from echo
- Add missing MSBuild path checks
- Include additional MSBuild directories
- Change encoding to UTF-8 without BOM

2. Add MSBuild.exe Location of VS 2022 Preview
